### PR TITLE
Add GB (Suffolk) school holidays

### DIFF
--- a/custom_components/school_holiday_sensor/holidays/gb.yaml
+++ b/custom_components/school_holiday_sensor/holidays/gb.yaml
@@ -1,0 +1,23 @@
+- name: Suffolk
+  holidays:
+    - name: Summer holidays 2025
+      date_from: 23-07-2025
+      date_till: 01-09-2025
+    - name: Autumn half term holiday 2025
+      date_from: 27-10-2025
+      date_till: 31-10-2026
+    - name: Christmas holidays 2025-2026
+      date_from: 20-12-2025
+      date_till: 04-01-2026
+    - name: Spring half term holiday 2026
+      date_from: 16-02-2026
+      date_till: 20-02-2026
+    - name: Easter holiday 2026
+      date_from: 28-03-2026
+      date_till: 12-04-2026
+    - name: Summer half term holiday 2025
+      date_from: 25-05-2026
+      date_till: 29-05-2026
+    - name: Summer holidays 2026
+      date_from: 20-07-2026
+      date_till: 01-09-2026


### PR DESCRIPTION
Add GB (Suffolk) school holidays

- Dates taken from https://www.suffolk.gov.uk/children-families-and-learning/schools/school-term-and-holiday-dates?nodeId=377b1344-a9f1-5e60-a0b1-6e0d72e1f39e&entryId=b83eaee7-26a5-5a30-a10c-742ded0ec704